### PR TITLE
Release kernel sources

### DIFF
--- a/README
+++ b/README
@@ -397,4 +397,3 @@ IF SOMETHING GOES WRONG:
 
    gdb'ing a non-running kernel currently fails because gdb (wrongly)
    disregards the starting offset for which the kernel is compiled.
-


### PR DESCRIPTION
The Linux Kernel is released under the GNU GPL V2.0 Licence and it is your legal duty to release the sources.